### PR TITLE
Fix/dont create synopsis if exist

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -48,7 +48,10 @@ class SynopsisType(object):
 COURSE_PAGE_TITLE_TEMPLATE = "Category:{title} ({id})"
 COURSE_PAGE_TEXT_TEMPLATE = textwrap.dedent("""\
                               Page for course "{title}" with id = {id}
+
                               {stepik_base}/course/{id}
+
+                              {{{{#categorytree:{{{{PAGENAME}}}}}}}}
                               [[Category:Courses]]
                               """)
 COURSE_PAGE_SUMMARY_TEMPLATE = 'Create page for course id={id}'
@@ -56,7 +59,10 @@ COURSE_PAGE_SUMMARY_TEMPLATE = 'Create page for course id={id}'
 LESSON_PAGE_TITLE_TEMPLATE = "Category:{title} ({id})"
 LESSON_PAGE_TEXT_TEMPLATE = textwrap.dedent("""\
                               Page for lesson "{title}" with id = {id}
+
                               {stepik_base}/lesson/{id}
+
+                              {{{{#categorytree:{{{{PAGENAME}}}}}}}}
                               [[Category:Lessons]]
                               """)
 LESSON_PAGE_SUMMARY_TEMPLATE = 'Create page for lesson id={id}'
@@ -64,6 +70,7 @@ LESSON_PAGE_SUMMARY_TEMPLATE = 'Create page for lesson id={id}'
 STEP_PAGE_TITLE_TEMPLATE = 'Step {position} ({id})'
 STEP_PAGE_TEXT_TEMPLATE = textwrap.dedent("""\
                             {content}
+
                             [[Category:Steps]]
                             [[{lesson}]]
                             """)

--- a/tasks.py
+++ b/tasks.py
@@ -4,35 +4,36 @@ import logging
 import settings
 from constants import ContentType, SynopsisType, EMPTY_STEP_TEXT
 from exceptions import CreateSynopsisError
-from utils import make_synopsis_from_video, save_synopsis_to_wiki, add_lesson_to_course, WikiClient
+from utils import (make_synopsis_from_video, save_synopsis_to_wiki, add_lesson_to_course,
+                   get_stepik_client, get_wiki_client)
 
 pool = concurrent.futures.ProcessPoolExecutor()
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-def submit_create_synopsis_task(stepik_client, data):
-    pool.submit(create_synopsis_task, stepik_client, data)
+def submit_create_synopsis_task(data):
+    pool.submit(create_synopsis_task, data)
 
 
-def create_synopsis_task(stepik_client, data):
+def create_synopsis_task(data):
     logger.info('start task with args %s', data)
-    wiki_client = WikiClient(settings.WIKI_LOGIN, settings.WIKI_PASSWORD)
     try:
+        stepik_client = get_stepik_client()
         if data['type'] == SynopsisType.COURSE:
             course_id = data['pk']
             lessons = stepik_client.get_lessons_by_course(course_id)
             course = stepik_client.get_course(course_id)
             for lesson in lessons:
-                synopsis = create_synopsis_for_lesson(wiki_client, lesson, stepik_client)
-                save_synopsis_to_wiki(wiki_client, synopsis)
-                add_lesson_to_course(wiki_client, course, lesson)
+                synopsis = create_synopsis_for_lesson(lesson)
+                save_synopsis_to_wiki(synopsis)
+                add_lesson_to_course(course, lesson)
 
         elif data['type'] == SynopsisType.LESSON:
             lesson_id = data['pk']
             lesson = stepik_client.get_lesson(lesson_id)
-            synopsis = create_synopsis_for_lesson(wiki_client, lesson, stepik_client)
-            save_synopsis_to_wiki(wiki_client, synopsis)
+            synopsis = create_synopsis_for_lesson(lesson)
+            save_synopsis_to_wiki(synopsis)
         else:
             step_id = data['pk']
             step = stepik_client.get_step(step_id)
@@ -40,10 +41,10 @@ def create_synopsis_task(stepik_client, data):
             synopsis = {
                 'lesson': lesson,
                 'steps': [
-                    create_synopsis_for_step(wiki_client, step)
+                    create_synopsis_for_step(step)
                 ]
             }
-            save_synopsis_to_wiki(wiki_client, synopsis)
+            save_synopsis_to_wiki(synopsis)
 
         logger.info('task with args %s completed', data)
     except CreateSynopsisError:
@@ -51,7 +52,8 @@ def create_synopsis_task(stepik_client, data):
         return
 
 
-def create_synopsis_for_lesson(wiki_client, lesson, stepik_client):
+def create_synopsis_for_lesson(lesson):
+    stepik_client = get_stepik_client()
     synopsis = {
         'lesson': lesson,
         'steps': []
@@ -59,13 +61,15 @@ def create_synopsis_for_lesson(wiki_client, lesson, stepik_client):
 
     for step_id in lesson['steps']:
         step = stepik_client.get_step(step_id)
-        synopsis['steps'].append(create_synopsis_for_step(wiki_client, step))
+        synopsis['steps'].append(create_synopsis_for_step(step))
 
     logger.info('synopsis creation for lesson (id = %s) ended', lesson['id'])
     return synopsis
 
 
-def create_synopsis_for_step(wiki_client, step):
+def create_synopsis_for_step(step):
+    wiki_client = get_wiki_client()
+
     if wiki_client.is_page_for_step_exist(step):
         return {
             'step': step,

--- a/tasks.py
+++ b/tasks.py
@@ -44,8 +44,10 @@ def create_synopsis_task(stepik_client, data):
                 ]
             }
             save_synopsis_to_wiki(wiki_client, synopsis)
+
+        logger.info('task with args %s completed', data)
     except CreateSynopsisError:
-        logger.exception('Failed to create or save synopsis')
+        logger.exception('task with args %s failed', data)
         return
 
 

--- a/utils.py
+++ b/utils.py
@@ -224,52 +224,14 @@ class WikiClient(object):
             logger.exception(msg)
             raise CreateSynopsisError('msg={}; error={}'.format(msg, e))
 
-    def get_url_by_page_id(self, page_id):
-        try:
-            response = self.session.get(action='query', prop='info', pageids=page_id, inprop='url')
-        except (APIError, RequestException) as e:
-            raise CreateSynopsisError(str(e))
-        url = response['query']['pages'][str(page_id)]['fullurl']
-        return url
-
-    def get_url_by_page_title(self, title):
-        try:
-            response = self.session.post(action='query', titles=title)
-        except (APIError, RequestException) as e:
-            raise CreateSynopsisError(str(e))
-
-        page_id = int(list(response['query']['pages'])[0])
-        if page_id < 0:
-            return None
-
-        return self.get_url_by_page_id(page_id)
-
     def get_or_create_page_for_step(self, lesson, step, content):
         lesson_page_title = LESSON_PAGE_TITLE_TEMPLATE.format(title=lesson['title'], id=lesson['id'])
         text = STEP_PAGE_TEXT_TEMPLATE.format(content=self._prepare_content(content), lesson=lesson_page_title)
         title = STEP_PAGE_TITLE_TEMPLATE.format(position=step['position'], id=step['id'])
         summary = STEP_PAGE_SUMMARY_TEMPLATE.format(id=step['id'])
 
-        page_url = self.get_url_by_page_title(title)
-        if page_url:
-            return page_url
-
-        try:
-            response = self.session.post(action='edit',
-                                         title=title,
-                                         section=0,
-                                         summary=summary,
-                                         text=text,
-                                         token=self.token,
-                                         createonly=True)
-        except RequestException as e:
-            raise CreateSynopsisError(str(e))
-        except APIError:
-            logger.exception('mwapi.errors.APIError: articleexists: - its OK')
-            return self.get_url_by_page_title(title)
-
-        page_url = self._extract_url_from_response(response)
-        logger.info('created page for step (step_id = %s, page_url = %s)', step['id'], page_url)
+        page_url = self._get_or_create_page(title, text, summary)
+        logger.info('page for step (step_id = %s, page_url = %s)', step['id'], page_url)
         return page_url
 
     def get_or_create_page_for_lesson(self, lesson):
@@ -279,26 +241,8 @@ class WikiClient(object):
                                                 id=lesson['id'])
         summary = LESSON_PAGE_SUMMARY_TEMPLATE.format(id=lesson['id'])
 
-        page_url = self.get_url_by_page_title(title)
-        if page_url:
-            return page_url
-
-        try:
-            response = self.session.post(action='edit',
-                                         title=title,
-                                         section=0,
-                                         summary=summary,
-                                         text=text,
-                                         token=self.token,
-                                         createonly=True)
-        except RequestException as e:
-            raise CreateSynopsisError(str(e))
-        except APIError:
-            logger.exception('mwapi.errors.APIError: articleexists: - its OK')
-            return self.get_url_by_page_title(title)
-
-        page_url = self._extract_url_from_response(response)
-        logger.info('created page for lesson (lesson_id = %s, page_url = %s)', lesson['id'], page_url)
+        page_url = self._get_or_create_page(title, text, summary)
+        logger.info('page for lesson (lesson_id = %s, page_url = %s)', lesson['id'], page_url)
         return page_url
 
     def get_or_create_page_for_course(self, course):
@@ -308,46 +252,13 @@ class WikiClient(object):
                                                 id=course['id'])
         summary = COURSE_PAGE_SUMMARY_TEMPLATE.format(id=course['id'])
 
-        page_url = self.get_url_by_page_title(title)
-        if page_url:
-            return page_url
-
-        try:
-            response = self.session.post(action='edit',
-                                         title=title,
-                                         section=0,
-                                         summary=summary,
-                                         text=text,
-                                         token=self.token,
-                                         createonly=True)
-        except RequestException as e:
-            raise CreateSynopsisError(str(e))
-        except APIError:
-            logger.exception('mwapi.errors.APIError: articleexists: - its OK')
-            return self.get_url_by_page_title(title)
-
-        page_url = self._extract_url_from_response(response)
-        logger.info('created page for course (course_id = %s, page_url = %s)', course['id'], page_url)
+        page_url = self._get_or_create_page(title, text, summary)
+        logger.info('page for course (course_id = %s, page_url = %s)', course['id'], page_url)
         return page_url
 
-    def _extract_url_from_response(self, response):
-        if response['edit']['result'] == 'Success':
-            page_id = response['edit']['pageid']
-            url = self.get_url_by_page_id(page_id)
-            return url
-        else:
-            raise CreateSynopsisError("Cant extract url from response, response = {}"
-                                      .format(response))
-
-    @staticmethod
-    def _prepare_content(content):
-        result = []
-        for item in content:
-            if item['type'] == ContentType.TEXT:
-                result.append(pypandoc.convert_text(item['content'], format='html', to='mediawiki'))
-            elif item['type'] == ContentType.IMG:
-                result.append('<img width="50%" src="{}">'.format(item['content']))
-        return '\n\n'.join(result)
+    def is_page_for_step_exist(self, step):
+        title = STEP_PAGE_TITLE_TEMPLATE.format(position=step['position'], id=step['id'])
+        return self._is_page_with_title_exist(title)
 
     def add_text_to_page(self, page_title, text, summary):
         try:
@@ -370,6 +281,73 @@ class WikiClient(object):
             return categories
         except Exception as e:
             raise CreateSynopsisError(str(e))
+
+    def _get_or_create_page(self, title, text, summary):
+        if self._is_page_with_title_exist(title):
+            return self._get_url_by_page_title(title)
+
+        return self._create_page(title, text, summary)
+
+    def _create_page(self, title, text, summary):
+        try:
+            response = self.session.post(action='edit',
+                                         title=title,
+                                         section=0,
+                                         summary=summary,
+                                         text=text,
+                                         token=self.token,
+                                         createonly=True)
+        except RequestException as e:
+            raise CreateSynopsisError(str(e))
+        except APIError:
+            logger.exception('mwapi.errors.APIError: articleexists: - its OK')
+            return self._get_url_by_page_title(title)
+
+        page_url = self._extract_url_from_response(response)
+        logger.info('created page with url %s', page_url)
+        return page_url
+
+    def _get_url_by_page_id(self, page_id):
+        try:
+            response = self.session.get(action='query', prop='info', pageids=page_id, inprop='url')
+        except (APIError, RequestException) as e:
+            raise CreateSynopsisError(str(e))
+        url = response['query']['pages'][str(page_id)]['fullurl']
+        return url
+
+    def _get_url_by_page_title(self, title):
+        try:
+            response = self.session.post(action='query', titles=title)
+        except (APIError, RequestException) as e:
+            raise CreateSynopsisError(str(e))
+
+        page_id = int(list(response['query']['pages'])[0])
+        if page_id < 0:
+            return None
+
+        return self._get_url_by_page_id(page_id)
+
+    def _extract_url_from_response(self, response):
+        if response['edit']['result'] == 'Success':
+            page_id = response['edit']['pageid']
+            url = self._get_url_by_page_id(page_id)
+            return url
+        else:
+            raise CreateSynopsisError("Cant extract url from response, response = {}"
+                                      .format(response))
+
+    @staticmethod
+    def _prepare_content(content):
+        result = []
+        for item in content:
+            if item['type'] == ContentType.TEXT:
+                result.append(pypandoc.convert_text(item['content'], format='html', to='mediawiki'))
+            elif item['type'] == ContentType.IMG:
+                result.append('<img width="50%" src="{}">'.format(item['content']))
+        return '\n\n'.join(result)
+
+    def _is_page_with_title_exist(self, title):
+        return self._get_url_by_page_title(title) is not None
 
 
 def save_synopsis_to_wiki(synopsis):

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,4 @@
 import argparse
-import json
 import logging
 import os
 import subprocess
@@ -24,6 +23,24 @@ from recognize import VideoRecognition, AudioRecognition
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
+
+_stepik_client = None
+_wiki_client = None
+
+
+def get_stepik_client():
+    global _stepik_client
+    if _stepik_client is None:
+        _stepik_client = StepikClient(client_id=settings.STEPIK_CLIENT_ID,
+                                      client_secret=settings.STEPIK_CLIENT_SECRET)
+    return _stepik_client
+
+
+def get_wiki_client():
+    global _wiki_client
+    if _wiki_client is None:
+        _wiki_client = WikiClient(settings.WIKI_LOGIN, settings.WIKI_PASSWORD)
+    return _wiki_client
 
 
 def merge_audio_and_video(keyframes, recognized_audio):
@@ -350,7 +367,8 @@ class WikiClient(object):
         return self._get_url_by_page_title(title) is not None
 
 
-def save_synopsis_to_wiki(wiki_client, synopsis):
+def save_synopsis_to_wiki(synopsis):
+    wiki_client = get_wiki_client()
     lesson = synopsis['lesson']
     lesson_wiki_url = wiki_client.get_or_create_page_for_lesson(lesson)
     response = {
@@ -377,7 +395,9 @@ def save_synopsis_to_wiki(wiki_client, synopsis):
     return response
 
 
-def add_lesson_to_course(wiki_client, course, lesson):
+def add_lesson_to_course(course, lesson):
+    wiki_client = get_wiki_client()
+
     course_url = wiki_client.get_or_create_page_for_course(course)
     lesson_url = wiki_client.get_or_create_page_for_lesson(lesson)
 

--- a/utils.py
+++ b/utils.py
@@ -402,4 +402,7 @@ def validate_synopsis_request(data):
     if not isinstance(data.get('pk'), int):
         return False
 
+    if data['pk'] <= 0:
+        return False
+
     return True

--- a/utils.py
+++ b/utils.py
@@ -350,8 +350,7 @@ class WikiClient(object):
         return self._get_url_by_page_title(title) is not None
 
 
-def save_synopsis_to_wiki(synopsis):
-    wiki_client = WikiClient(settings.WIKI_LOGIN, settings.WIKI_PASSWORD)
+def save_synopsis_to_wiki(wiki_client, synopsis):
     lesson = synopsis['lesson']
     lesson_wiki_url = wiki_client.get_or_create_page_for_lesson(lesson)
     response = {
@@ -378,9 +377,7 @@ def save_synopsis_to_wiki(synopsis):
     return response
 
 
-def add_lesson_to_course(course, lesson):
-    wiki_client = WikiClient(settings.WIKI_LOGIN, settings.WIKI_PASSWORD)
-
+def add_lesson_to_course(wiki_client, course, lesson):
     course_url = wiki_client.get_or_create_page_for_course(course)
     lesson_url = wiki_client.get_or_create_page_for_lesson(lesson)
 

--- a/utils.py
+++ b/utils.py
@@ -373,7 +373,7 @@ def save_synopsis_to_wiki(wiki_client, synopsis):
             }
         )
 
-    logger.info('wiki urls', response)
+    logger.info('wiki urls %s', response)
     return response
 
 

--- a/webserver.py
+++ b/webserver.py
@@ -11,7 +11,6 @@ from utils import StepikClient, validate_synopsis_request
 logging.basicConfig(format='[%(asctime)s]%(levelname)s:%(name)s:%(message)s')
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
-stepik_client = None
 
 
 class MainHandler(tornado.web.RequestHandler):
@@ -31,14 +30,11 @@ class MainHandler(tornado.web.RequestHandler):
             self.set_status(400)
             return
 
-        submit_create_synopsis_task(stepik_client, data)
+        submit_create_synopsis_task(data)
         self.set_status(200)
 
 
 def make_app():
-    global stepik_client
-    stepik_client = StepikClient(client_id=settings.STEPIK_CLIENT_ID,
-                                 client_secret=settings.STEPIK_CLIENT_SECRET)
     return tornado.web.Application([
         (r'/synopsis', MainHandler),
     ])

--- a/webserver.py
+++ b/webserver.py
@@ -8,6 +8,7 @@ import settings
 from tasks import submit_create_synopsis_task
 from utils import StepikClient, validate_synopsis_request
 
+logging.basicConfig(format='[%(asctime)s]%(levelname)s:%(name)s:%(message)s')
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 stepik_client = None


### PR DESCRIPTION
- Немного порефакторил `WikiClient`
- Добавил проверку, что если для степа уже есть страница на wiki, то генерить конспект не нужно.
Иначе получалось, что про генерации курса происходило пересоздание конспектов всех шагов, входящих в этот курс.
- Добавил в шаблон страницы курса и урока CategoryTree

~пока делаю PR в `feature/synopsis-for-course`, когда [тот PR](https://github.com/StepicOrg/summary/pull/8) вмержится, поменяю на `master`~