### PR TITLE
Add section to wiki structure

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -41,9 +41,10 @@ class ContentType(object):
 class SynopsisType(object):
     STEP = 1
     LESSON = 2
-    COURSE = 3
+    SECTION = 3
+    COURSE = 4
 
-    ALL_TYPES = (STEP, LESSON, COURSE)
+    ALL_TYPES = (STEP, LESSON, SECTION, COURSE)
 
 COURSE_PAGE_TITLE_TEMPLATE = "Category:{title} ({id})"
 COURSE_PAGE_TEXT_TEMPLATE = textwrap.dedent("""\
@@ -55,6 +56,15 @@ COURSE_PAGE_TEXT_TEMPLATE = textwrap.dedent("""\
                               [[Category:Courses]]
                               """)
 COURSE_PAGE_SUMMARY_TEMPLATE = 'Create page for course id={id}'
+
+SECTION_PAGE_TITLE_TEMPLATE = "Category:{title} ({id})"
+SECTION_PAGE_TEXT_TEMPLATE = textwrap.dedent("""\
+                              Page for module "{title}" with id = {id}
+
+                              {{{{#categorytree:{{{{PAGENAME}}}}}}}}
+                              [[Category:Sections]]
+                              """)
+SECTION_PAGE_SUMMARY_TEMPLATE = 'Create page for section id={id}'
 
 LESSON_PAGE_TITLE_TEMPLATE = "Category:{title} ({id})"
 LESSON_PAGE_TEXT_TEMPLATE = textwrap.dedent("""\

--- a/constants.py
+++ b/constants.py
@@ -82,7 +82,7 @@ STEP_PAGE_TEXT_TEMPLATE = textwrap.dedent("""\
                             {content}
 
                             [[Category:Steps]]
-                            [[{lesson}]]
+                            [[{lesson}|{position:>3}]]
                             """)
 STEP_PAGE_SUMMARY_TEMPLATE = 'Create page for step id={id}'
 

--- a/tasks.py
+++ b/tasks.py
@@ -45,9 +45,6 @@ def create_synopsis_task(data):
         logger.exception('task with args %s failed', data)
         return
 
-    except Exception:
-        logger.exception('task with args %s failed', data)
-
 
 def create_synopsis_task_for_course(course):
     stepik_client = get_stepik_client()
@@ -55,7 +52,6 @@ def create_synopsis_task_for_course(course):
     for section_id in course['sections']:
         section = stepik_client.get_section(section_id)
         create_synopsis_task_for_section(section)
-        add_section_to_course(section, course)
 
 
 def create_synopsis_task_for_section(section):
@@ -68,7 +64,7 @@ def create_synopsis_task_for_section(section):
         lesson = stepik_client.get_lesson(unit['lesson'])
         synopsis = create_synopsis_for_lesson(lesson)
         save_synopsis_for_lesson_to_wiki(synopsis)
-        add_lesson_to_section(lesson, section)
+        add_lesson_to_section(lesson, unit['position'], section)
 
     add_section_to_course(section, course)
 

--- a/tasks.py
+++ b/tasks.py
@@ -4,8 +4,8 @@ import logging
 import settings
 from constants import ContentType, SynopsisType, EMPTY_STEP_TEXT
 from exceptions import CreateSynopsisError
-from utils import (make_synopsis_from_video, save_synopsis_to_wiki, add_lesson_to_course,
-                   get_stepik_client, get_wiki_client)
+from utils import (make_synopsis_from_video, save_synopsis_for_lesson_to_wiki, get_stepik_client,
+                   get_wiki_client, add_lesson_to_section, add_section_to_course)
 
 pool = concurrent.futures.ProcessPoolExecutor()
 logger = logging.getLogger(__name__)
@@ -18,38 +18,77 @@ def submit_create_synopsis_task(data):
 
 def create_synopsis_task(data):
     logger.info('start task with args %s', data)
+    stepik_client = get_stepik_client()
     try:
-        stepik_client = get_stepik_client()
         if data['type'] == SynopsisType.COURSE:
             course_id = data['pk']
-            lessons = stepik_client.get_lessons_by_course(course_id)
             course = stepik_client.get_course(course_id)
-            for lesson in lessons:
-                synopsis = create_synopsis_for_lesson(lesson)
-                save_synopsis_to_wiki(synopsis)
-                add_lesson_to_course(course, lesson)
+            create_synopsis_task_for_course(course)
+
+        elif data['type'] == SynopsisType.SECTION:
+            section_id = data['pk']
+            section = stepik_client.get_section(section_id)
+            create_synopsis_task_for_section(section)
 
         elif data['type'] == SynopsisType.LESSON:
             lesson_id = data['pk']
             lesson = stepik_client.get_lesson(lesson_id)
-            synopsis = create_synopsis_for_lesson(lesson)
-            save_synopsis_to_wiki(synopsis)
+            create_synopsis_task_for_lesson(lesson)
+
         else:
             step_id = data['pk']
             step = stepik_client.get_step(step_id)
-            lesson = stepik_client.get_lesson(step['lesson'])
-            synopsis = {
-                'lesson': lesson,
-                'steps': [
-                    create_synopsis_for_step(step)
-                ]
-            }
-            save_synopsis_to_wiki(synopsis)
+            create_synopsis_task_for_step(step)
 
         logger.info('task with args %s completed', data)
     except CreateSynopsisError:
         logger.exception('task with args %s failed', data)
         return
+
+    except Exception:
+        logger.exception('task with args %s failed', data)
+
+
+def create_synopsis_task_for_course(course):
+    stepik_client = get_stepik_client()
+
+    for section_id in course['sections']:
+        section = stepik_client.get_section(section_id)
+        create_synopsis_task_for_section(section)
+        add_section_to_course(section, course)
+
+
+def create_synopsis_task_for_section(section):
+    stepik_client = get_stepik_client()
+
+    course = stepik_client.get_course(section['course'])
+
+    for unit_id in section['units']:
+        unit = stepik_client.get_unit(unit_id)
+        lesson = stepik_client.get_lesson(unit['lesson'])
+        synopsis = create_synopsis_for_lesson(lesson)
+        save_synopsis_for_lesson_to_wiki(synopsis)
+        add_lesson_to_section(lesson, section)
+
+    add_section_to_course(section, course)
+
+
+def create_synopsis_task_for_lesson(lesson):
+    synopsis = create_synopsis_for_lesson(lesson)
+    save_synopsis_for_lesson_to_wiki(synopsis)
+
+
+def create_synopsis_task_for_step(step):
+    stepik_client = get_stepik_client()
+
+    lesson = stepik_client.get_lesson(step['lesson'])
+    synopsis = {
+        'lesson': lesson,
+        'steps': [
+            create_synopsis_for_step(step)
+        ]
+    }
+    save_synopsis_for_lesson_to_wiki(synopsis)
 
 
 def create_synopsis_for_lesson(lesson):

--- a/tests.py
+++ b/tests.py
@@ -6,7 +6,7 @@ import requests
 from tornado.testing import AsyncHTTPTestCase
 
 from constants import ContentType, SynopsisType
-from utils import save_synopsis_to_wiki
+from utils import save_synopsis_for_lesson_to_wiki
 from webserver import make_app
 
 app = make_app()
@@ -73,7 +73,7 @@ class FunctionalTest(AsyncHTTPTestCase):
         args = new_save_synopsis_to_wiki.call_args[1]
         synopsis = args['synopsis']
 
-        result = save_synopsis_to_wiki(synopsis=synopsis)
+        result = save_synopsis_for_lesson_to_wiki(synopsis=synopsis)
 
         self.assertEquals(real_lesson_id, result['wiki_url_lesson']['lesson']['id'])
 

--- a/utils.py
+++ b/utils.py
@@ -186,29 +186,29 @@ class StepikClient(object):
         self.session.headers.update({'Authorization': 'Bearer ' + self.token})
 
     def get_course(self, course_id):
-        return self._get_object('course', course_id)
+        return self._get_object('courses', course_id)
 
     def get_section(self, section_id):
-        return self._get_object('section', section_id)
+        return self._get_object('sections', section_id)
 
     def get_unit(self, unit_id):
-        return self._get_object('unit', unit_id)
+        return self._get_object('units', unit_id)
 
     def get_lesson(self, lesson_id):
-        return self._get_object('lesson', lesson_id)
+        return self._get_object('lessons', lesson_id)
 
     def get_step(self, step_id):
-        return self._get_object('step', step_id)
+        return self._get_object('steps', step_id)
 
     def _get_object(self, object_type, object_id):
-        response = self.session.get('{base_url}/api/{type}s/{id}'.format(base_url=settings.STEPIK_BASE_URL,
-                                                                         type=object_type,
-                                                                         id=object_id))
+        response = self.session.get('{base_url}/api/{type}/{id}'.format(base_url=settings.STEPIK_BASE_URL,
+                                                                        type=object_type,
+                                                                        id=object_id))
         if not response:
             raise CreateSynopsisError('Failed to get {type} page from stepik, status code = {status_code}'
                                       .format(type=object_type, status_code=response.status_code))
 
-        return response.json()['{}s'.format(object_type)][0]
+        return response.json()[object_type][0]
 
 
 class WikiClient(object):

--- a/utils.py
+++ b/utils.py
@@ -224,7 +224,9 @@ class WikiClient(object):
 
     def get_or_create_page_for_step(self, lesson, step, content):
         lesson_page_title = LESSON_PAGE_TITLE_TEMPLATE.format(title=lesson['title'], id=lesson['id'])
-        text = STEP_PAGE_TEXT_TEMPLATE.format(content=self._prepare_content(content), lesson=lesson_page_title)
+        text = STEP_PAGE_TEXT_TEMPLATE.format(content=self._prepare_content(content),
+                                              lesson=lesson_page_title,
+                                              position=step['position'])
         title = STEP_PAGE_TITLE_TEMPLATE.format(position=step['position'], id=step['id'])
         summary = STEP_PAGE_SUMMARY_TEMPLATE.format(id=step['id'])
 
@@ -272,7 +274,7 @@ class WikiClient(object):
             self.session.post(action='edit',
                               title=page_title,
                               summary=summary,
-                              appendtext=text,
+                              appendtext='\n{}'.format(text),
                               token=self.token,
                               nocreate=True)
         except Exception as e:
@@ -389,7 +391,7 @@ def add_section_to_course(section, course):
     wiki_client = get_wiki_client()
 
     section_url = wiki_client.get_or_create_page_for_section(section)
-    course_url = wiki_client.get_or_create_page_for_lesson(course)
+    course_url = wiki_client.get_or_create_page_for_course(course)
 
     logger.info('add section {section} to course {course}'.format(section=section_url,
                                                                   course=course_url))
@@ -399,12 +401,14 @@ def add_section_to_course(section, course):
 
     section_categories = wiki_client.get_page_categories(section_page_title)
     if course_page_title not in section_categories:
+        course_link = '[[{title}|{position:>3}]]'.format(title=course_page_title,
+                                                         position=section['position'])
         wiki_client.add_text_to_page(page_title=section_page_title,
-                                     text='[[{}]]'.format(course_page_title),
+                                     text=course_link,
                                      summary='add section to course')
 
 
-def add_lesson_to_section(lesson, section):
+def add_lesson_to_section(lesson, lesson_position, section):
     wiki_client = get_wiki_client()
 
     lesson_url = wiki_client.get_or_create_page_for_lesson(lesson)
@@ -418,8 +422,10 @@ def add_lesson_to_section(lesson, section):
 
     lesson_categories = wiki_client.get_page_categories(lesson_page_title)
     if section_page_title not in lesson_categories:
+        section_link = '[[{title}|{position:>3}]]'.format(title=section_page_title,
+                                                          position=lesson_position)
         wiki_client.add_text_to_page(page_title=lesson_page_title,
-                                     text='[[{}]]'.format(section_page_title),
+                                     text=section_link,
                                      summary='add lesson to section')
 
 

--- a/utils.py
+++ b/utils.py
@@ -17,7 +17,8 @@ from constants import (VIDEOS_DOWNLOAD_CHUNK_SIZE, VIDEOS_DOWNLOAD_MAX_SIZE, FFM
                        STEP_PAGE_TITLE_TEMPLATE, STEP_PAGE_TEXT_TEMPLATE,
                        STEP_PAGE_SUMMARY_TEMPLATE, LESSON_PAGE_SUMMARY_TEMPLATE, ContentType,
                        SynopsisType, COURSE_PAGE_TITLE_TEMPLATE, COURSE_PAGE_TEXT_TEMPLATE,
-                       COURSE_PAGE_SUMMARY_TEMPLATE)
+                       COURSE_PAGE_SUMMARY_TEMPLATE, SECTION_PAGE_TITLE_TEMPLATE, SECTION_PAGE_TEXT_TEMPLATE,
+                       SECTION_PAGE_SUMMARY_TEMPLATE)
 from exceptions import CreateSynopsisError
 from recognize import VideoRecognition, AudioRecognition
 
@@ -185,49 +186,29 @@ class StepikClient(object):
         self.session.headers.update({'Authorization': 'Bearer ' + self.token})
 
     def get_course(self, course_id):
-        response = self.session.get('{base_url}/api/courses/{id}'.format(base_url=settings.STEPIK_BASE_URL,
-                                                                         id=course_id))
-        if not response:
-            raise CreateSynopsisError('Failed to get courses page from stepik, status code = {status_code}'
-                                      .format(status_code=response.status_code))
+        return self._get_object('course', course_id)
 
-        return response.json()['courses'][0]
+    def get_section(self, section_id):
+        return self._get_object('section', section_id)
+
+    def get_unit(self, unit_id):
+        return self._get_object('unit', unit_id)
 
     def get_lesson(self, lesson_id):
-        response = self.session.get('{base_url}/api/lessons/{id}'.format(base_url=settings.STEPIK_BASE_URL,
-                                                                         id=lesson_id))
-        if not response:
-            raise CreateSynopsisError('Failed to get lessons page from stepik, status code = {status_code}'
-                                      .format(status_code=response.status_code))
-
-        return response.json()['lessons'][0]
-
-    def get_lessons_by_course(self, course_id):
-        lessons = []
-        cur_page = 1
-        while True:
-            response = self.session.get('{base_url}/api/lessons?course={course_id}&page={page}'
-                                        .format(base_url=settings.STEPIK_BASE_URL,
-                                                course_id=course_id,
-                                                page=cur_page))
-            if not response:
-                raise CreateSynopsisError('Failed to get lessons page from stepik, status code = {status_code}'
-                                          .format(status_code=response.status_code))
-            lessons.extend(response.json()['lessons'])
-
-            if not response.json()['meta']['has_next']:
-                return lessons
-
-            cur_page += 1
+        return self._get_object('lesson', lesson_id)
 
     def get_step(self, step_id):
-        response = self.session.get('{base_url}/api/steps/{id}'.format(base_url=settings.STEPIK_BASE_URL,
-                                                                       id=step_id))
-        if not response:
-            raise CreateSynopsisError('Failed to get steps page from stepik, status code = {status_code}'
-                                      .format(status_code=response.status_code))
+        return self._get_object('step', step_id)
 
-        return response.json()['steps'][0]
+    def _get_object(self, object_type, object_id):
+        response = self.session.get('{base_url}/api/{type}s/{id}'.format(base_url=settings.STEPIK_BASE_URL,
+                                                                         type=object_type,
+                                                                         id=object_id))
+        if not response:
+            raise CreateSynopsisError('Failed to get {type} page from stepik, status code = {status_code}'
+                                      .format(type=object_type, status_code=response.status_code))
+
+        return response.json()['{}s'.format(object_type)][0]
 
 
 class WikiClient(object):
@@ -260,6 +241,15 @@ class WikiClient(object):
 
         page_url = self._get_or_create_page(title, text, summary)
         logger.info('page for lesson (lesson_id = %s, page_url = %s)', lesson['id'], page_url)
+        return page_url
+
+    def get_or_create_page_for_section(self, section):
+        title = SECTION_PAGE_TITLE_TEMPLATE.format(title=section['title'], id=section['id'])
+        text = SECTION_PAGE_TEXT_TEMPLATE.format(title=section['title'], id=section['id'])
+        summary = SECTION_PAGE_SUMMARY_TEMPLATE.format(id=section['id'])
+
+        page_url = self._get_or_create_page(title, text, summary)
+        logger.info('page for section (section_id = %s, page_url = %s)', section['id'], page_url)
         return page_url
 
     def get_or_create_page_for_course(self, course):
@@ -367,7 +357,7 @@ class WikiClient(object):
         return self._get_url_by_page_title(title) is not None
 
 
-def save_synopsis_to_wiki(synopsis):
+def save_synopsis_for_lesson_to_wiki(synopsis):
     wiki_client = get_wiki_client()
     lesson = synopsis['lesson']
     lesson_wiki_url = wiki_client.get_or_create_page_for_lesson(lesson)
@@ -395,21 +385,42 @@ def save_synopsis_to_wiki(synopsis):
     return response
 
 
-def add_lesson_to_course(course, lesson):
+def add_section_to_course(section, course):
     wiki_client = get_wiki_client()
 
-    course_url = wiki_client.get_or_create_page_for_course(course)
-    lesson_url = wiki_client.get_or_create_page_for_lesson(lesson)
+    section_url = wiki_client.get_or_create_page_for_section(section)
+    course_url = wiki_client.get_or_create_page_for_lesson(course)
 
-    logger.info('add lesson {lesson} to course {course}'.format(lesson=lesson_url, course=course_url))
+    logger.info('add section {section} to course {course}'.format(section=section_url,
+                                                                  course=course_url))
 
+    section_page_title = SECTION_PAGE_TITLE_TEMPLATE.format(title=section['title'], id=section['id'])
     course_page_title = COURSE_PAGE_TITLE_TEMPLATE.format(title=course['title'], id=course['id'])
-    lesson_page_title = LESSON_PAGE_TITLE_TEMPLATE.format(title=lesson['title'], id=lesson['id'])
 
-    course_link = '[[{}]]'.format(course_page_title)
+    section_categories = wiki_client.get_page_categories(section_page_title)
+    if course_page_title not in section_categories:
+        wiki_client.add_text_to_page(page_title=section_page_title,
+                                     text='[[{}]]'.format(course_page_title),
+                                     summary='add section to course')
+
+
+def add_lesson_to_section(lesson, section):
+    wiki_client = get_wiki_client()
+
+    lesson_url = wiki_client.get_or_create_page_for_lesson(lesson)
+    section_url = wiki_client.get_or_create_page_for_section(section)
+
+    logger.info('add lesson {lesson} to section {section}'.format(lesson=lesson_url,
+                                                                  section=section_url))
+
+    lesson_page_title = LESSON_PAGE_TITLE_TEMPLATE.format(title=lesson['title'], id=lesson['id'])
+    section_page_title = SECTION_PAGE_TITLE_TEMPLATE.format(title=section['title'], id=section['id'])
+
     lesson_categories = wiki_client.get_page_categories(lesson_page_title)
-    if course_page_title not in lesson_categories:
-        wiki_client.add_text_to_page(lesson_page_title, course_link, 'add lesson to course')
+    if section_page_title not in lesson_categories:
+        wiki_client.add_text_to_page(page_title=lesson_page_title,
+                                     text='[[{}]]'.format(section_page_title),
+                                     summary='add lesson to section')
 
 
 def validate_synopsis_request(data):

--- a/webserver.py
+++ b/webserver.py
@@ -4,9 +4,8 @@ import tornado.escape
 import tornado.ioloop
 import tornado.web
 
-import settings
 from tasks import submit_create_synopsis_task
-from utils import StepikClient, validate_synopsis_request
+from utils import validate_synopsis_request
 
 logging.basicConfig(format='[%(asctime)s]%(levelname)s:%(name)s:%(message)s')
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Сейчас на вики есть 3 типа страниц:
- курс
- урок
- шаг

Иерархия осуществляется за счет механизма категорий. Сортировка страниц внутри категорий происходит в лексикографическом порядке.

Проблемы:
- уроки внутри курса имеют неправильный порядок
- если уроков много - это сложно воспринимать (т.к. на одном уровне иерархии очень много элементов)
- шаги внутри урока имеют неправильный порядок, если их > 9 (т.к. Step 10 идет раньше чем Step 2)

Что нужно сделать:

- [x]   Добавить модули в иерархию
- [x]   Исправить сортировку

Задача [EDY-6214](https://vyahhi.myjetbrains.com/youtrack/issue/EDY-6214)